### PR TITLE
Bugfixes

### DIFF
--- a/DFIR-O365RC/Get-DefenderforO365.ps1
+++ b/DFIR-O365RC/Get-DefenderforO365.ps1
@@ -54,7 +54,7 @@
     if ((Test-Path $unifiedauditfolder) -eq $false){New-Item $unifiedauditfolder -Type Directory}
     "Processing O365 logs for day $($datetoprocess)"| Write-Log -LogPath $logfile
     $token = Get-MsalToken -Silent -PublicClientApplication $app -LoginHint $user -Scopes "https://outlook.office365.com/.default"    
-    $sessionName = "EXO_" + $datetoprocess
+    $sessionName = "EXO_" + [guid]::NewGuid().ToString()
     $tenant = ($token.Account.UserName).split("@")[1]
     $outputdate = "{0:yyyy-MM-dd}" -f ($datetoprocess)
     $foldertoprocess = $unifiedauditfolder + "\" + $datetoprocess
@@ -75,7 +75,7 @@
                 Get-PSSession | Remove-PSSession -Confirm:$false
                 $token = Get-MsalToken -Silent -PublicClientApplication $app -LoginHint $user -Scopes "https://outlook.office365.com/.default"
                 Start-Sleep -Seconds 15
-                $sessionName = "EXO_" + $operationsset.GroupName
+                $sessionName = "EXO_" + [guid]::NewGuid().ToString()
                 Connect-EXOPsearchUnified -token $token -sessionName $sessionName -logfile $logfile
                 $trysearch = Search-UnifiedAuditLog -StartDate $newstartdate -EndDate $newenddate -RecordType $RecordType  -ResultSize 1
                 }
@@ -87,7 +87,7 @@
                     {
                     "More than 50000 $($RecordType) records between {0:yyyy-MM-dd} {0:HH:mm:ss} and {1:yyyy-MM-dd} {1:HH:mm:ss} - some records might be missing" -f ($newstarthour,$newendhour) | Write-Log -LogPath $logfile -LogLevel "Warning" 
                     }
-                $sessionName  = ((get-date -Format 'u').Tostring()).replace(" ","_") 
+                $sessionName  = [guid]::NewGuid().ToString()
                 Get-LargeUnifiedAuditLog -sessionName $sessionName -StartDate $newstartdate -EndDate $newenddate -RecordType $recordtype -outputfile $outputfile -logfile $logfile -requesttype "Records"
                 }        
         }    

--- a/DFIR-O365RC/Get-O365Full.ps1
+++ b/DFIR-O365RC/Get-O365Full.ps1
@@ -104,7 +104,7 @@ Function Get-O365Full {
     if ((Test-Path $unifiedauditfolder) -eq $false){New-Item $unifiedauditfolder -Type Directory}
     "Processing O365 logs for day $($datetoprocess)"| Write-Log -LogPath $logfile
     $token = Get-MsalToken -Silent -PublicClientApplication $app -LoginHint $user -Scopes "https://outlook.office365.com/.default"
-    $sessionName = "EXO_" + $datetoprocess
+    $sessionName = "EXO_" + [guid]::NewGuid().ToString()
     Connect-EXOPsearchUnified -token $token -sessionName $sessionName -logfile $logfile
     $foldertoprocess = $unifiedauditfolder + "\" + $datetoprocess
     if ((Test-Path $foldertoprocess) -eq $false){New-Item $foldertoprocess -Type Directory}
@@ -145,20 +145,20 @@ Function Get-O365Full {
                 Get-PSSession | Remove-PSSession -Confirm:$false
                 $token = Get-MsalToken -Silent -PublicClientApplication $app -LoginHint $user -Scopes "https://outlook.office365.com/.default"
                 Start-Sleep -Seconds 15
-                $sessionName = "EXO_" + $datetoprocess
+                $sessionName = "EXO_" + [guid]::NewGuid().ToString()
                 Connect-EXOPsearchUnified -token $token -sessionName $sessionName -logfile $logfile
                 $trysearch = Search-UnifiedAuditLog -StartDate $newstarthour -EndDate $newendhour -RecordType $recordtype -ResultSize 1
-                }
+            }
             if($trysearch)
                 {
                     $countobjects = $trysearch.ResultCount
-                    "Dumping $($countobjects) $($recordtype) records between {0:yyyy-MM-dd} {0:HH:mm:ss} and {1:yyyy-MM-dd} {1:HH:mm:ss}" -f ($newstarthour,$newendhour) | Write-Log -LogPath $logfile
-                    if($countobjects -gt 50000)
-                    {
-                        "More than 50000 $($recordtype) records between {0:yyyy-MM-dd} {0:HH:mm:ss} and {1:yyyy-MM-dd} {1:HH:mm:ss} - some records might be missing" -f ($newstarthour,$newendhour) | Write-Log -LogPath $logfile -LogLevel "Warning" 
-                    }
-                        $sessionName  = ((get-date -Format 'u').Tostring()).replace(" ","_") 
-                        Get-LargeUnifiedAuditLog -sessionName $sessionName -StartDate $newstarthour -EndDate $newendhour -RecordType $recordtype -outputfile $outputfile -logfile $logfile -requesttype "Records"
+					"Dumping $($countobjects) $($recordtype) records between {0:yyyy-MM-dd} {0:HH:mm:ss} and {1:yyyy-MM-dd} {1:HH:mm:ss}" -f ($newstarthour,$newendhour) | Write-Log -LogPath $logfile
+					if($countobjects -gt 50000)
+					{
+						"More than 50000 $($recordtype) records between {0:yyyy-MM-dd} {0:HH:mm:ss} and {1:yyyy-MM-dd} {1:HH:mm:ss} - some records might be missing" -f ($newstarthour,$newendhour) | Write-Log -LogPath $logfile -LogLevel "Warning" 
+					}
+					$sessionName  = [guid]::NewGuid().ToString()
+					Get-LargeUnifiedAuditLog -sessionName $sessionName -StartDate $newstarthour -EndDate $newendhour -RecordType $recordtype -outputfile $outputfile -logfile $logfile -requesttype "Records"
                 }
             }
 

--- a/DFIR-O365RC/Get-O365Light.ps1
+++ b/DFIR-O365RC/Get-O365Light.ps1
@@ -57,7 +57,7 @@
 
     $myObject = [PSCustomObject]@{
         GroupName= "AzureAD";
-        Operations = '"Register connector",Verify domain","Add verified domain","Remove verified domain","Disable Desktop Sso for a specific domain","Add application","Add app role assignment to service principal","Update application","Update application – Certificates and secrets management","Update application – Certificates and secrets management ","Add delegated permission grant","Add OAuth2PermissionGrant","Add unverified domain","Add group", "Add member to group", "Delete group", "Remove member from group", "Update group","Consent to application", "Add app role assignment grant to user", "Add delegation entry", "Add service principal", "Add service principal credentials", "Remove delegation entry", "Remove service principal", "Remove service principal credentials", "Set delegation entry", "Add member to role", "Remove member from role",  "Add app role assignment grant to user", "New-ConditionalAccessPolicy", "Set-AdminAuditLogConfig", "Set-ConditionalAccessPolicy", "Update domain", "Set federation settings on domain", "Set domain authentication", "Add partner to company", "Add domain to company"'
+        Operations = '"Register connector","Verify domain","Add verified domain","Remove verified domain","Disable Desktop Sso for a specific domain","Add application","Add app role assignment to service principal","Update application","Update application – Certificates and secrets management","Update application – Certificates and secrets management ","Add delegated permission grant","Add OAuth2PermissionGrant","Add unverified domain","Add group", "Add member to group", "Delete group", "Remove member from group", "Update group","Consent to application", "Add app role assignment grant to user", "Add delegation entry", "Add service principal", "Add service principal credentials", "Remove delegation entry", "Remove service principal", "Remove service principal credentials", "Set delegation entry", "Add member to role", "Remove member from role",  "Add app role assignment grant to user", "New-ConditionalAccessPolicy", "Set-AdminAuditLogConfig", "Set-ConditionalAccessPolicy", "Update domain", "Set federation settings on domain", "Set domain authentication", "Add partner to company", "Add domain to company"'
     }
 
     $Alloperations += $myObject
@@ -133,7 +133,7 @@
     if ((Test-Path $unifiedauditfolder) -eq $false){New-Item $unifiedauditfolder -Type Directory}
     "Processing O365 logs for day $($datetoprocess)"| Write-Log -LogPath $logfile
     $token = Get-MsalToken -Silent -PublicClientApplication $app -LoginHint $user -Scopes "https://outlook.office365.com/.default"    
-    $sessionName = "EXO_" + $datetoprocess
+    $sessionName = "EXO_" + [guid]::NewGuid().ToString()
     $tenant = ($token.Account.UserName).split("@")[1]
     $outputdate = "{0:yyyy-MM-dd}" -f ($datetoprocess)
     $foldertoprocess = $unifiedauditfolder + "\" + $datetoprocess
@@ -156,7 +156,7 @@
                 Get-PSSession | Remove-PSSession -Confirm:$false
                 $token = Get-MsalToken -Silent -PublicClientApplication $app -LoginHint $user -Scopes "https://outlook.office365.com/.default"
                 Start-Sleep -Seconds 15
-                $sessionName = "EXO_" + $operationsset.GroupName
+                $sessionName = "EXO_" + [guid]::NewGuid().ToString()
                 Connect-EXOPsearchUnified -token $token -sessionName $sessionName -logfile $logfile
                 $trysearch = Search-UnifiedAuditLog -StartDate $newstartdate -EndDate $newenddate -operations $operationsset.Operations  -ResultSize 1
                 }
@@ -168,8 +168,7 @@
                     {
                         "More than 50000 $($operationsset.GroupName) records between {0:yyyy-MM-dd} {0:HH:mm:ss} and {1:yyyy-MM-dd} {1:HH:mm:ss} - some records might be missing" -f ($newstarthour,$newendhour) | Write-Log -LogPath $logfile -LogLevel "Warning" 
                     }
-                        $sessionName  = ((get-date -Format 'u').Tostring()).replace(" ","_") 
-                        #$sessionName = (Get-Random).tostring()
+                        $sessionName  = [guid]::NewGuid().ToString()
                         Get-LargeUnifiedAuditLog -sessionName $sessionName -StartDate $newstartdate -EndDate $newenddate -operations $operationsset.Operations -outputfile $outputfile -logfile $logfile -requesttype "Operations"
                 }
             }

--- a/DFIR-O365RC/Search-O365.ps1
+++ b/DFIR-O365RC/Search-O365.ps1
@@ -13,7 +13,7 @@
     Search for Python user agent in unified audit logs
 
     .EXAMPLE
-    Search-O365 -stardate $startdate -enddate $enddate -IPAddresses "X.X.X.X"
+    Search-O365 -stardate $startdate -enddate $enddate -IPAddresses X.X.X.X
     Dump all the unified audit logs entries by the specified IP addresses. You specify multiple IP addresses separated by commas.
     #>
     
@@ -76,7 +76,7 @@
     if ((Test-Path $unifiedauditfolder) -eq $false){New-Item $unifiedauditfolder -Type Directory}
     "Processing O365 logs for day $($datetoprocess)"| Write-Log -LogPath $logfile
     $token = Get-MsalToken -Silent -PublicClientApplication $app -LoginHint $user -Scopes "https://outlook.office365.com/.default"    
-    $sessionName = "EXO_" + $datetoprocess
+    $sessionName = "EXO_" + [guid]::NewGuid().ToString()
     $tenant = ($token.Account.UserName).split("@")[1]
     $outputdate = "{0:yyyy-MM-dd}" -f ($datetoprocess)
     $foldertoprocess = $unifiedauditfolder + "\" + $datetoprocess
@@ -102,7 +102,7 @@
                 Get-PSSession | Remove-PSSession -Confirm:$false
                 $token = Get-MsalToken -Silent -PublicClientApplication $app -LoginHint $user -Scopes "https://outlook.office365.com/.default"
                 Start-Sleep -Seconds 15
-                $sessionName = "EXO_" + $operationsset.GroupName
+                $sessionName = "EXO_" + [guid]::NewGuid().ToString()
                 Connect-EXOPsearchUnified -token $token -sessionName $sessionName -logfile $logfile
                 if($requesttype -eq "freetext")
                     {$trysearch = Search-UnifiedAuditLog -StartDate $newstartdate -EndDate $newenddate -FreeText $searchstring -ResultSize 1}
@@ -119,7 +119,7 @@
                     {
                         "More than 50000 records between {0:yyyy-MM-dd} {0:HH:mm:ss} and {1:yyyy-MM-dd} {1:HH:mm:ss} - some records might be missing" -f ($newstarthour,$newendhour) | Write-Log -LogPath $logfile -LogLevel "Warning" 
                     }
-                        $sessionName  = ((get-date -Format 'u').Tostring()).replace(" ","_") 
+                        $sessionName  = [guid]::NewGuid().ToString()
                         if($requesttype -eq "UserIds")
                         {Get-LargeUnifiedAuditLog -sessionName $sessionName -StartDate $newstartdate -EndDate $newenddate -searchtable $searchstring -outputfile $outputfile -logfile $logfile -requesttype $requesttype }
                         else {


### PR DESCRIPTION
Fix two bugs :

- SessionName were not randomized. Generally this is not an issue, because threads/PSSession launching at the same time does not occur often. When using Get-O365Full, a lot more of those collisions can occur. Therefore, the SessionName needs to be changed from a predictable (date-based) string to a random Guid

- Sometimes, the UAL API will "lock" itself and give incorrect results. This is due to some internal timeout by Microsoft. When this occurs, ResultCount = 0 or ResultIndex = -1. We check for such results and discard them. We temporize for 5 minutes before trying again.